### PR TITLE
Fix admin sale orders controller comment

### DIFF
--- a/app/controllers/admin/sale_orders_controller.rb
+++ b/app/controllers/admin/sale_orders_controller.rb
@@ -1,4 +1,4 @@
-# app/controllers/admin/sales_orders_controller.rb
+# app/controllers/admin/sale_orders_controller.rb
 class Admin::SaleOrdersController < ApplicationController
   before_action :authenticate_user!
   before_action :authorize_admin!


### PR DESCRIPTION
## Summary
- correct the header comment for the admin sale orders controller

## Testing
- `bundle exec rails test` *(fails: ruby 3.2.2 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6844cf4e140c83319557a03d8b0a043c