### PR TITLE
Fix admin dashboard test route

### DIFF
--- a/test/controllers/admin/dashboard_controller_test.rb
+++ b/test/controllers/admin/dashboard_controller_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class Admin::DashboardControllerTest < ActionDispatch::IntegrationTest
   test "should get index" do
-    get admin_dashboard_index_url
+    get admin_dashboard_url
     assert_response :success
   end
 end


### PR DESCRIPTION
## Summary
- correct the dashboard controller test route to use `admin_dashboard_url`

## Testing
- `bin/rails test test/controllers/admin/dashboard_controller_test.rb -v` *(fails: ruby 3.2.2 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6844cf6e42a88331aa0dee440109475d