### PR TITLE
Fix typo in routes comment

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,7 +32,7 @@ Rails.application.routes.draw do
       # Image removal for ActiveStorage
       delete "images/:image_id", to: "products#purge_image", as: :purge_image
 
-      # Product serach as JSON
+      # Product search as JSON
       collection do
         get "search"
       end


### PR DESCRIPTION
## Summary
- correct typo in admin product search comment

## Testing
- `bin/rails test` *(fails: ruby-3.2.2 is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6844cf21b384833184cc835dd74f4fe1