### PR TITLE
Fix SaleOrder payment validation bug

### DIFF
--- a/app/models/sale_order.rb
+++ b/app/models/sale_order.rb
@@ -47,7 +47,7 @@ class SaleOrder < ApplicationRecord
       errors.add(:payment, "must exist to ship the order") unless payments.any?
       errors.add(:shipment, "must exist to ship the order") unless shipment.present?
     when "Delivered"
-      errors.add(:payment, "must exist to deliver the order") unless payment.any?
+      errors.add(:payment, "must exist to deliver the order") unless payments.any?
       errors.add(:shipment, "must exist to deliver the order") unless shipment.present?
 
     end


### PR DESCRIPTION
## Summary
- fix typo in payment validation method in `SaleOrder`

## Testing
- `bundle exec rspec` *(fails: ruby-3.2.2 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6844cdee37ac8331b32c136ecbb02ff2