### PR TITLE
Add new RSpec coverage

### DIFF
--- a/spec/controllers/admin/payments_controller_spec.rb
+++ b/spec/controllers/admin/payments_controller_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe Admin::PaymentsController, type: :controller do
+  let(:admin) { create(:user, :admin) }
+  let(:sale_order) { create(:sale_order) }
+
+  before { sign_in admin }
+
+  describe 'POST create' do
+    it 'creates a new payment for the sale order' do
+      expect {
+        post :create, params: { sale_order_id: sale_order.id, payment: { amount: 50.0, payment_method: 'efectivo', status: 'Completed' } }
+      }.to change(Payment, :count).by(1)
+
+      expect(Payment.last.sale_order).to eq(sale_order)
+    end
+  end
+end

--- a/spec/factories/sale_order_items.rb
+++ b/spec/factories/sale_order_items.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :sale_order_item do
+    association :sale_order
+    association :product
+    quantity { 1 }
+    unit_cost { 10.0 }
+    unit_discount { 0.0 }
+    unit_final_price { unit_cost }
+    total_line_cost { quantity * unit_final_price }
+    total_line_volume { 1.0 }
+    total_line_weight { 1.0 }
+  end
+end

--- a/spec/factories/sale_orders.rb
+++ b/spec/factories/sale_orders.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :sale_order do
+    association :user
+    order_date { Date.today }
+    subtotal { 100.0 }
+    tax_rate { 0.0 }
+    total_tax { 0.0 }
+    total_order_value { 100.0 }
+    status { "Pending" }
+  end
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe ApplicationHelper, type: :helper do
+  describe '#bootstrap_class_for' do
+    it 'returns success class for notice' do
+      expect(helper.bootstrap_class_for(:notice)).to eq('alert-success')
+    end
+
+    it 'returns info class for unknown key' do
+      expect(helper.bootstrap_class_for(:other)).to eq('alert-info')
+    end
+  end
+
+  describe '#currency_symbol_for' do
+    it 'returns symbol when known' do
+      expect(helper.currency_symbol_for('MXN')).to eq('$')
+    end
+
+    it 'returns code when unknown' do
+      expect(helper.currency_symbol_for('XYZ')).to eq('XYZ')
+    end
+  end
+end

--- a/spec/helpers/status_helper_spec.rb
+++ b/spec/helpers/status_helper_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe StatusHelper, type: :helper do
+  describe '#status_badge_class' do
+    it 'returns success class for Delivered' do
+      expect(helper.status_badge_class('Delivered')).to eq('bg-success')
+    end
+
+    it 'returns secondary class for unknown status' do
+      expect(helper.status_badge_class('Other')).to eq('bg-secondary')
+    end
+  end
+end

--- a/spec/models/cart_item_spec.rb
+++ b/spec/models/cart_item_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe CartItem, type: :model do
+  describe 'associations' do
+    it { should belong_to(:product) }
+  end
+end

--- a/spec/models/sale_order_item_spec.rb
+++ b/spec/models/sale_order_item_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe SaleOrderItem, type: :model do
+  describe 'associations' do
+    it { should belong_to(:sale_order) }
+    it { should belong_to(:product) }
+  end
+
+  describe 'validations' do
+    it { should validate_presence_of(:quantity) }
+    it { should validate_numericality_of(:quantity).is_greater_than(0) }
+    it { should validate_presence_of(:unit_cost) }
+    it { should validate_numericality_of(:unit_cost).is_greater_than_or_equal_to(0) }
+  end
+end

--- a/spec/models/shipment_spec.rb
+++ b/spec/models/shipment_spec.rb
@@ -1,13 +1,21 @@
 require 'rails_helper'
 
 RSpec.describe Shipment, type: :model do
-  describe "Validations" do
+  describe 'Validations' do
     it { should validate_presence_of(:carrier) }
     it { should validate_presence_of(:status) }
     it { should validate_presence_of(:tracking_number) }
   end
 
-  describe "Associations" do
-    it { should belong_to(:sale_order).with_foreign_key("sale_order_id") }
+  describe 'Associations' do
+    it { should belong_to(:sale_order).with_foreign_key('sale_order_id') }
+  end
+
+  describe 'custom date validation' do
+    it 'is invalid when actual_delivery is before estimated_delivery' do
+      shipment = Shipment.new(tracking_number: '123', carrier: 'UPS', sale_order: build(:sale_order), estimated_delivery: Date.today, actual_delivery: Date.yesterday)
+      expect(shipment).to be_invalid
+      expect(shipment.errors[:actual_delivery]).to be_present
+    end
   end
 end

--- a/spec/services/products/update_stats_service_spec.rb
+++ b/spec/services/products/update_stats_service_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe Products::UpdateStatsService, type: :service do
+  let(:product) { create(:product) }
+  let(:purchase_order) { create(:purchase_order) }
+  let!(:purchase_item) { create(:purchase_order_item, product: product, purchase_order: purchase_order, quantity: 5, unit_cost: 10.0, unit_additional_cost: 0) }
+  let(:sale_order) { create(:sale_order) }
+  let!(:sale_item) { create(:sale_order_item, product: product, sale_order: sale_order, quantity: 2, unit_final_price: 20.0, unit_cost: 20.0) }
+
+  it 'updates product stats based on related items' do
+    described_class.new(product).call
+    product.reload
+
+    expect(product.total_purchase_quantity).to eq(5)
+    expect(product.total_sales_quantity).to eq(2)
+    expect(product.total_purchase_value).to eq(50)
+    expect(product.total_sales_value).to eq(40)
+    expect(product.average_purchase_cost).to eq(10)
+    expect(product.average_sales_price).to eq(20)
+    expect(product.total_purchase_order).to eq(1)
+    expect(product.total_sales_order).to eq(1)
+    expect(product.total_units_sold).to eq(2)
+  end
+end


### PR DESCRIPTION
## Summary
- cover missing models with basic specs
- add helper specs
- add service spec for product stats
- test payment creation in admin controller
- extend shipment spec with date validator check

## Testing
- `bundle exec rspec` *(fails: bundler not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844d2a4d7448331a7123535fc5a6628