### PR TITLE
Unify flash styling

### DIFF
--- a/app/javascript/modules/flash_messages.js
+++ b/app/javascript/modules/flash_messages.js
@@ -1,13 +1,15 @@
 // Function to handle fading flash messages
 function handleFlashMessages() {
-  const flash = document.querySelector(".flash-message");
-  if (!flash) return;
-  
-  setTimeout(() => {
-    flash.classList.remove("show");
-    flash.classList.add("fade");
-    setTimeout(() => flash.remove(), 500);
-  }, 5000);
+  const flashes = document.querySelectorAll(".flash-message");
+  if (!flashes.length) return;
+
+  flashes.forEach((flash) => {
+    setTimeout(() => {
+      flash.classList.remove("show");
+      flash.classList.add("fade");
+      setTimeout(() => flash.remove(), 500);
+    }, 5000);
+  });
 }
 
 // Run for full page loads

--- a/app/views/admin/sale_orders/edit.html.erb
+++ b/app/views/admin/sale_orders/edit.html.erb
@@ -12,13 +12,15 @@
 <% end %>
 
 <% if flash[:notice] %>
-  <div class="alert alert-success">
+  <div class="alert alert-success alert-dismissible fade show flash-message" role="alert">
     <%= flash[:notice] %>
+    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
   </div>
 <% end %>
 <% if flash[:alert] %>
-  <div class="alert alert-danger">
+  <div class="alert alert-danger alert-dismissible fade show flash-message" role="alert">
     <%= flash[:alert] %>
+    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
   </div>
 <% end %>
 

--- a/app/views/customers/partials/_alerts.html.erb
+++ b/app/views/customers/partials/_alerts.html.erb
@@ -1,7 +1,0 @@
-<div class="container mt-3">
-  <% flash.each do |type, message| %>
-    <div class="alert <%= bootstrap_class_for(type) %> alert-dismissible fade show flash-message" role="alert">
-      <%= message %>
-    </div>
-  <% end %>
-</div>

--- a/app/views/layouts/_flash.html.erb
+++ b/app/views/layouts/_flash.html.erb
@@ -1,19 +1,8 @@
-<div class="container mx-auto">
+<div class="container mt-3" id="flash">
   <% flash.each do |key, message| %>
-    <div class="px-4 py-3 rounded text-center">
+    <div class="alert <%= bootstrap_class_for(key) %> alert-dismissible fade show flash-message" role="alert">
       <%= message %>
+      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
     </div>
   <% end %>
 </div>
-<% if flash.any? %>
-  <turbo-stream action="update" target="flash">
-    <template>
-      <% flash.each do |key, message| %>
-        <div class="alert alert-<%= key == 'notice' ? 'success' : 'danger' %> alert-dismissible fade show" role="alert">
-          <%= message %>
-          <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
-        </div>
-      <% end %>
-    </template>
-  </turbo-stream>
-<% end %>

--- a/app/views/layouts/customer.html.erb
+++ b/app/views/layouts/customer.html.erb
@@ -32,10 +32,10 @@
   </header>
 
   <!-- ✅ Main Content -->
-  <main class="container mt-4">
-    <%= render 'customers/partials/alerts' %>
-    <%= yield %>
-  </main>
+    <main class="container mt-4">
+      <%= render 'layouts/flash' %>
+      <%= yield %>
+    </main>
 
   <!-- ✅ Footer -->
   <%= render 'customers/partials/footer' %>


### PR DESCRIPTION
## Summary
- unify flash messages using a single Bootstrap-based partial
- remove old alerts partial from customer layout
- make flash fading JS handle multiple messages
- tweak sale orders edit screen to use unified flash markup

## Testing
- `bundle install`
- `RAILS_ENV=test bin/rails db:migrate`
- `bundle exec rspec` *(fails: expected 105 examples, 8 failures)*

------
https://chatgpt.com/codex/tasks/task_e_6851aedefcbc8331a4f292555bf16b6f